### PR TITLE
Field 015

### DIFF
--- a/formatter/pom.xml
+++ b/formatter/pom.xml
@@ -116,6 +116,116 @@
                     </environmentVariables>
                 </configuration>
             </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.directory}/dependency-jars/
+                            </outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+
+                    <!-- Unpack DB shema-->
+                    <execution>
+                        <id>unpack-cfg-test-resources</id>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/rawrepo</outputDirectory>
+                            <includes>rawrepo.sql</includes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>dk.dbc</groupId>
+                                    <artifactId>rawrepo-access</artifactId>
+                                    <version>1.4-SNAPSHOT</version>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>reserve-network-port</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>postgresql.port</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <!-- postgres -->
+            <plugin>
+                <groupId>dk.dbc</groupId>
+                <artifactId>postgresql-maven-plugin</artifactId>
+                <version>1.3-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>start-postgresql</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                            <pgPort>${postgresql.port}</pgPort>
+                            <pgDbName>rawrepo</pgDbName>
+                            <pgDbScripts>
+                                <param>${project.build.directory}/rawrepo/rawrepo.sql</param>
+                            </pgDbScripts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-postgresql</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>shutdown</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                    <systemPropertyVariables>
+                        <postgresql.port>${postgresql.port}</postgresql.port>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>    
 
@@ -147,7 +257,7 @@
         <dependency>
             <groupId>dk.dbc</groupId>
             <artifactId>rawrepo-access</artifactId>
-            <version>1.2-SNAPSHOT</version>
+            <version>1.4-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/javascript/JavascriptWorkerPool.java
+++ b/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/javascript/JavascriptWorkerPool.java
@@ -126,13 +126,13 @@ public class JavascriptWorkerPool {
         /**
          * Run script on content, adding data to solrInputDocument
          *
-         * @param records String[] containing collection of marcX records
+         * @param records MarcXChangeWrapper[] containing collection of marcX records
          * @param format The format to return
          * @param sets List of sets this request is allowed to see
          * @return
          * @throws Exception
          */
-        public String format(String[] records, String format, List<String> sets) throws Exception {
+        public String format(MarcXChangeWrapper[] records, String format, List<String> sets) throws Exception {
             if (!allowedFormats.contains(format)) {
                 throw new IllegalArgumentException("Format '" + format + "' not allowed. Formats allowed: " + allowedFormats);
             }

--- a/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/javascript/MarcXChangeWrapper.java
+++ b/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/javascript/MarcXChangeWrapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017 DBC A/S (http://dbc.dk/)
+ *
+ * This is part of dbc-rawrepo-oai-formatter-dw
+ *
+ * dbc-rawrepo-oai-formatter-dw is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dbc-rawrepo-oai-formatter-dw is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dk.dbc.rawrepo.oai.formatter.javascript;
+
+import dk.dbc.rawrepo.RecordId;
+import java.util.Objects;
+
+/*
+ * @author DBC {@literal <dbc.dk>}
+ */
+public class MarcXChangeWrapper {    
+    public final String content;
+    public final Record[] children;
+    
+    public MarcXChangeWrapper(String content, RecordId[] children) {
+        this.content = content;
+        this.children = new Record[children.length];
+        for (int i = 0; i < children.length; i++) {
+            RecordId child = children[i];
+            this.children[i] = new Record(child.getBibliographicRecordId(), child.getAgencyId());
+        }
+    }
+    
+    public static class Record {
+        public final String recId;
+        public final int agencyId;
+        
+        public Record(String recId, int agencyId) {
+            this.recId = recId;
+            this.agencyId = agencyId;            
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if(!(o instanceof Record)) {
+                return false;
+            }
+            Record other = (Record) o;
+            if(this.agencyId == other.agencyId && this.recId.equals(other.recId)) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 3;
+            hash = 71 * hash + Objects.hashCode(this.recId);
+            hash = 71 * hash + this.agencyId;
+            return hash;
+        }
+    }
+}

--- a/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/javascript/MarcXChangeWrapper.java
+++ b/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/javascript/MarcXChangeWrapper.java
@@ -18,7 +18,6 @@
  */
 package dk.dbc.rawrepo.oai.formatter.javascript;
 
-import dk.dbc.rawrepo.RecordId;
 import java.util.Objects;
 
 /*
@@ -26,32 +25,28 @@ import java.util.Objects;
  */
 public class MarcXChangeWrapper {    
     public final String content;
-    public final Record[] children;
+    public final RecordId[] children;
     
     public MarcXChangeWrapper(String content, RecordId[] children) {
         this.content = content;
-        this.children = new Record[children.length];
-        for (int i = 0; i < children.length; i++) {
-            RecordId child = children[i];
-            this.children[i] = new Record(child.getBibliographicRecordId(), child.getAgencyId());
-        }
+        this.children = children;        
     }
     
-    public static class Record {
+    public static class RecordId {
         public final String recId;
         public final int agencyId;
         
-        public Record(String recId, int agencyId) {
+        public RecordId(String recId, int agencyId) {
             this.recId = recId;
             this.agencyId = agencyId;            
         }
         
         @Override
         public boolean equals(Object o) {
-            if(!(o instanceof Record)) {
+            if(!(o instanceof RecordId)) {
                 return false;
             }
-            Record other = (Record) o;
+            RecordId other = (RecordId) o;
             if(this.agencyId == other.agencyId && this.recId.equals(other.recId)) {
                 return true;
             }

--- a/formatter/src/main/resources/javascript/MarcXchangeToOaiDc.use.js
+++ b/formatter/src/main/resources/javascript/MarcXchangeToOaiDc.use.js
@@ -27,6 +27,8 @@ var MarcXchangeToOaiDc = function() {
 
     Log.info( "Entering MarcXchangeToOaiDc module" );
 
+    //test
+
 
     /**
      * Function that is entry to create a complete Dublin Core Record.

--- a/formatter/src/main/resources/javascript/MarcXchangeToOaiDc.use.js
+++ b/formatter/src/main/resources/javascript/MarcXchangeToOaiDc.use.js
@@ -27,9 +27,6 @@ var MarcXchangeToOaiDc = function() {
 
     Log.info( "Entering MarcXchangeToOaiDc module" );
 
-    //test
-
-
     /**
      * Function that is entry to create a complete Dublin Core Record.
      *

--- a/formatter/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter/src/main/resources/javascript/OaiFormatter.test.js
@@ -365,6 +365,9 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
                 {
                     recId: "44816687",
                     agencyId: 870970
+                }, {
+                    recId: "44816679",
+                    agencyId: 870970
                 }
             ]
         }
@@ -381,6 +384,12 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
                 '<marcx:datafield ind1="0" ind2="0" tag="004">' +
                     '<marcx:subfield code="a">h</marcx:subfield>' +
                     '<marcx:subfield code="r">c</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="015">' +
+                    '<marcx:subfield code="a">44816687</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="015">' +
+                    '<marcx:subfield code="a">44816679</marcx:subfield>' +
                 '</marcx:datafield>' +
                 '<marcx:datafield ind1="0" ind2="0" tag="100">' +
                     '<marcx:subfield code="a">Knausgård</marcx:subfield>' +
@@ -480,21 +489,25 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
         {
             content: volumeRecordString,
             children: []
-        },
-        {
+        }, {
             content: sectionRecordString,
             children: [
                 {
                     recId: "23642468",
                     agencyId: 870970
+                }, {
+                    recId: "23642980",
+                    agencyId: 870970
                 }
             ]
-        },
-        {
+        }, {
             content: headRecordString,
             children: [
                 {
                     recId: "23642433",
+                    agencyId: 870970
+                }, {
+                    recId: "23644584",
                     agencyId: 870970
                 }
             ]
@@ -513,6 +526,12 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
                     '<marcx:subfield code="r">n</marcx:subfield>' +
                     '<marcx:subfield code="a">h</marcx:subfield>' +
                 '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="015">' +
+                    '<marcx:subfield code="a">23642433</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="015">' +
+                    '<marcx:subfield code="a">23644584</marcx:subfield>' +
+                '</marcx:datafield>' +
                 '<marcx:datafield ind1="0" ind2="0" tag="245">' +
                     '<marcx:subfield code="a">Forebyggelse af arbejdsulykker</marcx:subfield>' +
                 '</marcx:datafield>' +
@@ -529,6 +548,12 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
                 '</marcx:datafield>' +
                 '<marcx:datafield ind1="0" ind2="0" tag="014">' +
                     '<marcx:subfield code="a">23641348</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="015">' +
+                    '<marcx:subfield code="a">23642468</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="015">' +
+                    '<marcx:subfield code="a">23642980</marcx:subfield>' +
                 '</marcx:datafield>' +
                 '<marcx:datafield ind1="0" ind2="0" tag="245">' +
                     '<marcx:subfield code="n">2</marcx:subfield>' +
@@ -669,7 +694,7 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm NOT allowed set)", f
         {
             content: recordString,
             children: []
-        },
+        }
     ];   
 
     var error = new Error( "Format: illegal not allowed" );
@@ -744,28 +769,34 @@ UnitTest.addFixture( "Test convertXmlRecordStringsToMarcObjects", function( ) {
         {
             content: volumeRecordString,
             children: []
-        },
-        {
+        }, {
             content: sectionRecordString,
             children: [
                 {
                     recId: "23642468",
                     agencyId: 870970
+                }, {
+                    recId: "23642980",
+                    agencyId: 870970
                 }
             ]
-        },
-        {
+        }, {
             content: headRecordString,
             children: [
                 {
                     recId: "23642433",
                     agencyId: 870970
+                }, {
+                    recId: "23644584",
+                    agencyId: 870970
                 }
             ]
         }
-    ];                                   
+    ];
 
-    var actual = OaiFormatter.convertXmlRecordStringsToMarcObjects( records );
+    //first test (includeFields015 = true)
+    var includeFields015 = true;
+    var actual = OaiFormatter.convertXmlRecordStringsToMarcObjects( records, includeFields015 );
 
     var volumeRecordObject = new Record();
     volumeRecordObject.fromString(
@@ -780,6 +811,8 @@ UnitTest.addFixture( "Test convertXmlRecordStringsToMarcObjects", function( ) {
         '001 00 *a23642433 *b870970\n' +
         '004 00 *rn *as\n' +
         '014 00 *a23641348\n' +
+        '015 00 *a23642468\n' +
+        '015 00 *a23642980\n' +
         '245 00 *n2 *oIntern sikkerhedsdokumentation og -gennemgang'
     );
 
@@ -787,6 +820,8 @@ UnitTest.addFixture( "Test convertXmlRecordStringsToMarcObjects", function( ) {
     headRecordObject.fromString(
         '001 00 *a23641348 *b870970\n' +
         '004 00 *rn *ah\n' +
+        '015 00 *a23642433\n' +
+        '015 00 *a23644584\n' +
         '245 00 *aForebyggelse af arbejdsulykker'
     );
 
@@ -800,6 +835,46 @@ UnitTest.addFixture( "Test convertXmlRecordStringsToMarcObjects", function( ) {
 
     testName = "convertXmlRecordStringsToMarcObjects - third record";
     Assert.equalValue( testName, String( actual[ 2 ] ), String( expected[ 2 ] ) );
+
+
+    //second test includeFields015 = false
+    includeFields015 = false;
+    actual = OaiFormatter.convertXmlRecordStringsToMarcObjects( records, includeFields015 );
+
+    volumeRecordObject = new Record();
+    volumeRecordObject.fromString(
+        '001 00 *a23642468 *b870970\n' +
+        '004 00 *rn *ab\n' +
+        '014 00 *a23642433\n' +
+        '245 00 *g2.1 *aIntern sikkerhedsdokumentation *eudarbejdet af: Holstberg Management *eforfatter: Anne Gram'
+    );
+
+    sectionRecordObject = new Record();
+    sectionRecordObject.fromString(
+        '001 00 *a23642433 *b870970\n' +
+        '004 00 *rn *as\n' +
+        '014 00 *a23641348\n' +
+        '245 00 *n2 *oIntern sikkerhedsdokumentation og -gennemgang'
+    );
+
+    headRecordObject = new Record();
+    headRecordObject.fromString(
+        '001 00 *a23641348 *b870970\n' +
+        '004 00 *rn *ah\n' +
+        '245 00 *aForebyggelse af arbejdsulykker'
+    );
+
+    expected = [ volumeRecordObject, sectionRecordObject, headRecordObject ];
+
+    testName = "convertXmlRecordStringsToMarcObjects - first record";
+    Assert.equalValue( testName, String( actual[ 0 ] ), String( expected[ 0 ] ) );
+
+    testName = "convertXmlRecordStringsToMarcObjects - second record";
+    Assert.equalValue( testName, String( actual[ 1 ] ), String( expected[ 1 ] ) );
+
+    testName = "convertXmlRecordStringsToMarcObjects - third record";
+    Assert.equalValue( testName, String( actual[ 2 ] ), String( expected[ 2 ] ) );
+
 
 } );
 

--- a/formatter/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter/src/main/resources/javascript/OaiFormatter.test.js
@@ -35,7 +35,12 @@ UnitTest.addFixture( "Test formatRecords (format DC)", function() {
             '</marcx:datafield>' +
         '</marcx:record>';
 
-    var records = [ recordString ];
+    var records = [
+        {
+            content: recordString,
+            children: []
+        }
+    ];
 
     var expected =
         '<oai_dc:dc ' +
@@ -96,7 +101,21 @@ UnitTest.addFixture( "Test formatRecords (format DC)", function() {
             '</marcx:datafield>' +
         '</marcx:record>';
 
-    records = [ volumeRecordString, headRecordString ];
+    records = [
+        {
+            content: volumeRecordString,
+            children: []
+        },
+        {
+            content: headRecordString,
+            children: [
+                {
+                    recId: "44816687",
+                    agencyId: 870970
+                }
+            ]
+        }
+    ];
 
     expected =
         '<oai_dc:dc ' +
@@ -173,9 +192,32 @@ UnitTest.addFixture( "Test formatRecords (format DC)", function() {
             '<marcx:subfield code="a">Forebyggelse af arbejdsulykker</marcx:subfield>' +
             '</marcx:datafield>' +
         '</marcx:record>';
-
-    records = [ volumeRecordString, sectionRecordString, headRecordString ];
-
+    
+    records = [
+        {
+            content: volumeRecordString,
+            children: []
+        },
+        {
+            content: sectionRecordString,
+            children: [
+                {
+                    recId: "23642468",
+                    agencyId: 870970
+                }
+            ]
+        },
+        {
+            content: headRecordString,
+            children: [
+                {
+                    recId: "23642433",
+                    agencyId: 870970
+                }
+            ]
+        }
+    ];
+ 
     expected =
         '<oai_dc:dc ' +
         'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
@@ -230,7 +272,12 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
             '</marcx:datafield>' +
         '</marcx:record>';
 
-    var records = [ recordString ];
+    var records = [
+        {
+            content: recordString,
+            children: []
+        }
+    ];
 
     var expected =
         '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
@@ -306,8 +353,22 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
                 '<marcx:subfield code="c">roman</marcx:subfield>' +
             '</marcx:datafield>' +
         '</marcx:record>';
-
-    records = [ volumeRecordString, headRecordString ];
+                     
+    records = [
+        {
+            content: volumeRecordString,
+            children: []
+        },
+        {
+            content: headRecordString,
+            children: [
+                {
+                    recId: "44816687",
+                    agencyId: 870970
+                }
+            ]
+        }
+    ];
 
     expected =
         '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
@@ -414,8 +475,31 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm as allowed set)", fu
                 '<marcx:subfield code="a">Forebyggelse af arbejdsulykker</marcx:subfield>' +
             '</marcx:datafield>' +
         '</marcx:record>';
-
-    records = [ volumeRecordString, sectionRecordString, headRecordString ];
+                
+    records = [
+        {
+            content: volumeRecordString,
+            children: []
+        },
+        {
+            content: sectionRecordString,
+            children: [
+                {
+                    recId: "23642468",
+                    agencyId: 870970
+                }
+            ]
+        },
+        {
+            content: headRecordString,
+            children: [
+                {
+                    recId: "23642433",
+                    agencyId: 870970
+                }
+            ]
+        }
+    ];                              
 
     expected =
         '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
@@ -515,7 +599,12 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm NOT allowed set)", f
             '</marcx:datafield>' +
         '</marcx:record>';
 
-    var records = [ recordString ];
+    var records = [
+        {
+            content: recordString,
+            children: []
+        }
+    ];   
 
     var expected =
         '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
@@ -576,7 +665,12 @@ UnitTest.addFixture( "Test formatRecords (format marcx, bkm NOT allowed set)", f
             '</marcx:datafield>' +
         '</marcx:record>';
 
-    var records = [ recordString ];
+    var records = [
+        {
+            content: recordString,
+            children: []
+        },
+    ];   
 
     var error = new Error( "Format: illegal not allowed" );
 
@@ -645,8 +739,31 @@ UnitTest.addFixture( "Test convertXmlRecordStringsToMarcObjects", function( ) {
         '<marcx:subfield code="a">Forebyggelse af arbejdsulykker</marcx:subfield>' +
         '</marcx:datafield>' +
         '</marcx:record>';
-
-    var records = [ volumeRecordString, sectionRecordString, headRecordString ];
+    
+    var records = [
+        {
+            content: volumeRecordString,
+            children: []
+        },
+        {
+            content: sectionRecordString,
+            children: [
+                {
+                    recId: "23642468",
+                    agencyId: 870970
+                }
+            ]
+        },
+        {
+            content: headRecordString,
+            children: [
+                {
+                    recId: "23642433",
+                    agencyId: 870970
+                }
+            ]
+        }
+    ];                                   
 
     var actual = OaiFormatter.convertXmlRecordStringsToMarcObjects( records );
 

--- a/formatter/src/main/resources/javascript/OaiFormatter.use.js
+++ b/formatter/src/main/resources/javascript/OaiFormatter.use.js
@@ -31,10 +31,22 @@ var OaiFormatter = function() {
     /**
      * Formats MarcX records, either producing a Dublin Core record
      * or MarcX record(s)
-     *
+     * 
      * @function
      * @type {function}
-     * @param {String[]} records Array consisting of record, and its ancestors (ordered from closest ancestor)
+     * @param {MarcXChangeWrapper[]} records Array consisting of record, and its 
+     * ancestors (ordered from closest ancestor). Array items are instances of the 
+     * MarcXChangeWrapper Java class.
+     * 
+     * Example use of records:
+     * var head = records[2] // Assuming records, contain volume, section and head
+     * var content = head.content  // The actual xml
+     * var children = head.children;   
+     * for( var i = 0; i < children.length; i++ ) {
+     *      children[i].recId;
+     *      children[i].agencyId;
+     * }
+     * 
      * @param {String} format The format to return
      * @param {String[]} allowedSets Names of allowed OAI sets
      * @returns {String} DC or MarcX record(s)
@@ -102,7 +114,7 @@ var OaiFormatter = function() {
         var recordObjects = [ ];
 
         for ( var i = 0; i < records.length; i++ ) {
-            var recordObject = MarcXchange.marcXchangeToMarcRecord( records[ i ] );
+            var recordObject = MarcXchange.marcXchangeToMarcRecord( records[ i ].content );
             recordObjects.push( recordObject );
         }
 

--- a/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/javascript/JavascriptWorkerPoolTest.java
+++ b/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/javascript/JavascriptWorkerPoolTest.java
@@ -18,8 +18,8 @@
  */
 package dk.dbc.rawrepo.oai.formatter.javascript;
 
-import dk.dbc.rawrepo.RecordId;
 import dk.dbc.rawrepo.oai.formatter.javascript.JavascriptWorkerPool.JavaScriptWorker;
+import dk.dbc.rawrepo.oai.formatter.javascript.MarcXChangeWrapper.RecordId;
 import java.util.Arrays;
 import org.junit.Test;
 import static org.junit.Assert.*;

--- a/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/javascript/JavascriptWorkerPoolTest.java
+++ b/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/javascript/JavascriptWorkerPoolTest.java
@@ -18,7 +18,9 @@
  */
 package dk.dbc.rawrepo.oai.formatter.javascript;
 
+import dk.dbc.rawrepo.RecordId;
 import dk.dbc.rawrepo.oai.formatter.javascript.JavascriptWorkerPool.JavaScriptWorker;
+import java.util.Arrays;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -27,6 +29,42 @@ import static org.junit.Assert.*;
  * @author DBC {@literal <dbc.dk>}
  */
 public class JavascriptWorkerPoolTest {
+    
+    private static String HEAD = "<marcx:record format=\"danMARC2\" type=\"Bibliographic\" xmlns:marcx=\"info:lc/xmlns/marcxchange-v1\">" +
+        "<marcx:leader>00000c    2200000   4500</marcx:leader>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"001\">" +
+                "<marcx:subfield code=\"a\">123456</marcx:subfield>" +
+                "<marcx:subfield code=\"b\">870970</marcx:subfield>" +
+            "</marcx:datafield>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"004\">" +
+                "<marcx:subfield code=\"r\">c</marcx:subfield>" +
+                "<marcx:subfield code=\"a\">b</marcx:subfield>" +
+            "</marcx:datafield>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"014\">" +
+                "<marcx:subfield code=\"a\">44783851</marcx:subfield>" +
+            "</marcx:datafield>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"245\">" +
+                "<marcx:subfield code=\"g\">4. bok</marcx:subfield>" +
+            "</marcx:datafield>" +
+        "</marcx:record>";
+    
+    private static String VOLUME = "<marcx:record format=\"danMARC2\" type=\"Bibliographic\" xmlns:marcx=\"info:lc/xmlns/marcxchange-v1\">" +
+        "<marcx:leader>00000c    2200000   4500</marcx:leader>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"001\">" +
+                "<marcx:subfield code=\"a\">234567</marcx:subfield>" +
+                "<marcx:subfield code=\"b\">870970</marcx:subfield>" +
+            "</marcx:datafield>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"004\">" +
+                "<marcx:subfield code=\"r\">c</marcx:subfield>" +
+                "<marcx:subfield code=\"a\">b</marcx:subfield>" +
+            "</marcx:datafield>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"014\">" +
+                "<marcx:subfield code=\"a\">44783851</marcx:subfield>" +
+            "</marcx:datafield>" +
+            "<marcx:datafield ind1=\"0\" ind2=\"0\" tag=\"245\">" +
+                "<marcx:subfield code=\"g\">4. bok</marcx:subfield>" +
+            "</marcx:datafield>" +
+        "</marcx:record>";
     
     final JavascriptWorkerPool pool = new JavascriptWorkerPool(1);
 
@@ -39,5 +77,23 @@ public class JavascriptWorkerPoolTest {
         try(JavaScriptWorker w = pool.borrowWorker()) {
             assertTrue(w.getAllowedFormats().size() > 0);
         }        
+    }
+    
+    /**
+     * Testing integration between Java and JavaScript.
+     * JavaScript processes a Java MarcXChangeWrapper[] array
+     * without throwing exception.
+     * @throws Exception 
+     */
+    @Test
+    public void testFormat() throws Exception {
+        try(JavaScriptWorker w = pool.borrowWorker()) {
+            MarcXChangeWrapper[] records = new MarcXChangeWrapper[] {
+                new MarcXChangeWrapper(VOLUME, new RecordId[]{new RecordId("123456", 870970)}),
+                new MarcXChangeWrapper(HEAD, new RecordId[]{new RecordId("234567", 870970)})
+            };
+        
+            w.format(records, "marcx", Arrays.asList("nat"));
+        }  
     }
 }

--- a/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/resources/OaiFormatterResourceIT.java
+++ b/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/resources/OaiFormatterResourceIT.java
@@ -90,16 +90,16 @@ public class OaiFormatterResourceIT {
         assertEquals(0, collection[0].children.length);
         
         assertEquals(new HashSet<>(Arrays.asList(
-                new MarcXChangeWrapper.Record(volume1.getId().getBibliographicRecordId(), 
+                new MarcXChangeWrapper.RecordId(volume1.getId().getBibliographicRecordId(), 
                         volume1.getId().getAgencyId()),
-                new MarcXChangeWrapper.Record(volume2.getId().getBibliographicRecordId(), 
+                new MarcXChangeWrapper.RecordId(volume2.getId().getBibliographicRecordId(), 
                         volume2.getId().getAgencyId()))), 
                 new HashSet<>(Arrays.asList(collection[1].children)));
         
         assertEquals(new HashSet<>(Arrays.asList(
-                new MarcXChangeWrapper.Record(section1.getId().getBibliographicRecordId(), 
+                new MarcXChangeWrapper.RecordId(section1.getId().getBibliographicRecordId(), 
                         section1.getId().getAgencyId()),
-                new MarcXChangeWrapper.Record(section2.getId().getBibliographicRecordId(), 
+                new MarcXChangeWrapper.RecordId(section2.getId().getBibliographicRecordId(), 
                         section2.getId().getAgencyId()))), 
                 new HashSet<>(Arrays.asList(collection[2].children)));
     }
@@ -127,9 +127,9 @@ public class OaiFormatterResourceIT {
         assertEquals(0, collection[0].children.length);
         
         assertEquals(new HashSet<>(Arrays.asList(
-                new MarcXChangeWrapper.Record(volume1.getId().getBibliographicRecordId(), 
+                new MarcXChangeWrapper.RecordId(volume1.getId().getBibliographicRecordId(), 
                         volume1.getId().getAgencyId()),
-                new MarcXChangeWrapper.Record(volume2.getId().getBibliographicRecordId(), 
+                new MarcXChangeWrapper.RecordId(volume2.getId().getBibliographicRecordId(), 
                         volume2.getId().getAgencyId()))), 
                 new HashSet<>(Arrays.asList(collection[1].children)));
 

--- a/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/resources/OaiFormatterResourceIT.java
+++ b/formatter/src/test/java/dk/dbc/rawrepo/oai/formatter/resources/OaiFormatterResourceIT.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2017 DBC A/S (http://dbc.dk/)
+ *
+ * This is part of dbc-rawrepo-oai-formatter-dw
+ *
+ * dbc-rawrepo-oai-formatter-dw is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dbc-rawrepo-oai-formatter-dw is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dk.dbc.rawrepo.oai.formatter.resources;
+
+import dk.dbc.commons.testutils.postgres.connection.PostgresITConnection;
+import dk.dbc.marcxmerge.MarcXChangeMimeType;
+import dk.dbc.rawrepo.RawRepoDAO;
+import dk.dbc.rawrepo.RawRepoException;
+import dk.dbc.rawrepo.Record;
+import dk.dbc.rawrepo.RecordId;
+import dk.dbc.rawrepo.oai.formatter.javascript.MarcXChangeWrapper;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/*
+ * @author DBC {@literal <dbc.dk>}
+ */
+public class OaiFormatterResourceIT {
+    
+    private Connection connection;
+    private PostgresITConnection postgres;
+
+    @Before
+    public void setup() throws SQLException, ClassNotFoundException {
+        postgres = new PostgresITConnection("rawrepo");        
+        postgres.clearTables("relations", "records");
+        connection = postgres.getConnection();
+        connection.setAutoCommit(false);
+        connection.prepareStatement("SET log_statement = 'all';").execute();        
+    }
+    
+    @After
+    public void after() throws SQLException {
+        connection.rollback();
+        postgres.close();
+        connection.close();
+    }
+    
+    public OaiFormatterResourceIT() {
+    }
+
+    @Test
+    public void testFetchRecordCollection_withHeadSectionVolume() throws Exception {
+                
+        RawRepoDAO dao = RawRepoDAO.builder(connection).build();
+        
+        Record head = createRecord("bib1", dao);
+        Record section1 = createRecord("bib2", dao);
+        Record section2 = createRecord("bib3", dao);
+        Record volume1 = createRecord("bib4", dao);
+        Record volume2 = createRecord("bib5", dao);
+
+        setChild(head, section1, dao);
+        setChild(head, section2, dao);
+        setChild(section1, volume1, dao);
+        setChild(section1, volume2, dao);
+        
+        MarcXChangeWrapper[] collection = OaiFormatterResource.fetchRecordCollection(
+                volume1.getId().getAgencyId(), 
+                volume1.getId().getBibliographicRecordId(), dao);
+                               
+        assertEquals(3, collection.length);        
+        assertEquals("content_bib4", collection[0].content);
+        assertEquals("content_bib2", collection[1].content);
+        assertEquals("content_bib1", collection[2].content);        
+
+        assertEquals(0, collection[0].children.length);
+        
+        assertEquals(new HashSet<>(Arrays.asList(
+                new MarcXChangeWrapper.Record(volume1.getId().getBibliographicRecordId(), 
+                        volume1.getId().getAgencyId()),
+                new MarcXChangeWrapper.Record(volume2.getId().getBibliographicRecordId(), 
+                        volume2.getId().getAgencyId()))), 
+                new HashSet<>(Arrays.asList(collection[1].children)));
+        
+        assertEquals(new HashSet<>(Arrays.asList(
+                new MarcXChangeWrapper.Record(section1.getId().getBibliographicRecordId(), 
+                        section1.getId().getAgencyId()),
+                new MarcXChangeWrapper.Record(section2.getId().getBibliographicRecordId(), 
+                        section2.getId().getAgencyId()))), 
+                new HashSet<>(Arrays.asList(collection[2].children)));
+    }
+    
+    @Test
+    public void testFetchRecordCollection_withHeadVolume() throws Exception {
+                
+        RawRepoDAO dao = RawRepoDAO.builder(connection).build();
+        
+        Record head = createRecord("bib1", dao);
+        Record volume1 = createRecord("bib4", dao);
+        Record volume2 = createRecord("bib5", dao);
+
+        setChild(head, volume1, dao);
+        setChild(head, volume2, dao);
+        
+        MarcXChangeWrapper[] collection = OaiFormatterResource.fetchRecordCollection(
+                volume1.getId().getAgencyId(), 
+                volume1.getId().getBibliographicRecordId(), dao);
+                               
+        assertEquals(2, collection.length);        
+        assertEquals("content_bib4", collection[0].content);
+        assertEquals("content_bib1", collection[1].content);
+
+        assertEquals(0, collection[0].children.length);
+        
+        assertEquals(new HashSet<>(Arrays.asList(
+                new MarcXChangeWrapper.Record(volume1.getId().getBibliographicRecordId(), 
+                        volume1.getId().getAgencyId()),
+                new MarcXChangeWrapper.Record(volume2.getId().getBibliographicRecordId(), 
+                        volume2.getId().getAgencyId()))), 
+                new HashSet<>(Arrays.asList(collection[1].children)));
+
+    }
+    
+    void setChild(Record head, Record child, RawRepoDAO dao) throws RawRepoException{
+        Set<RecordId> relationsFrom = dao.getRelationsFrom(child.getId());
+        relationsFrom.add(head.getId());
+        dao.setRelationsFrom(child.getId(), relationsFrom);
+    }
+    
+    Record createRecord(String bibId, RawRepoDAO dao) throws RawRepoException {
+        RecordId id = new RecordId(bibId, 870970);
+        Record record = dao.fetchRecord(id.getBibliographicRecordId(), id.getAgencyId());
+        record.setMimeType(MarcXChangeMimeType.MARCXCHANGE);
+        record.setContent(("content_" + bibId).getBytes());
+        dao.saveRecord(record);
+        return record;
+    }
+    
+}


### PR DESCRIPTION
015 fields are not stored explicitly in rawrepo marcx records, but they may be derived from relations in rawrepo. 

- Java code has been added to fetch relations from rawrepo and include child information in the request to the javascript formatter.

- Javascript modified to add needed 015 fields to the marcx records