### PR TITLE
Bugfix #21524 

### DIFF
--- a/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/resources/OaiFormatterResource.java
+++ b/formatter/src/main/java/dk/dbc/rawrepo/oai/formatter/resources/OaiFormatterResource.java
@@ -111,6 +111,8 @@ public class OaiFormatterResource {
     static MarcXChangeWrapper[] fetchRecordCollection(int agencyId, String bibRecId, RawRepoDAO dao) throws RawRepoException, UnsupportedEncodingException{
         ArrayList<MarcXChangeWrapper> collection = new ArrayList<>();
         Record r = dao.fetchRecord(bibRecId, agencyId);
+        dao.expandRecord(r,false);
+
         while(r != null) {
 
             Set<dk.dbc.rawrepo.RecordId> parents = dao.getRelationsParents(r.getId());


### PR DESCRIPTION
When fetching MarcRecords, the record should be expanded so that it includes Authority records (among other things).